### PR TITLE
Publish GitHub repository to GitHub pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        env:
+          # Set base for Vite if publishing to user/organization site root
+          # For project pages, set VITE_BASE to "/<repo-name>/"
+          VITE_BASE: "/"
+        run: |
+          npm run build
+          # Create 404.html for SPA routing fallback
+          cp dist/index.html dist/404.html
+          # Ensure GitHub Pages does not run Jekyll
+          touch dist/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,11 +32,15 @@ jobs:
         run: npm ci
 
       - name: Build
-        env:
-          # Set base for Vite if publishing to user/organization site root
-          # For project pages, set VITE_BASE to "/<repo-name>/"
-          VITE_BASE: "/"
         run: |
+          # Compute correct Vite base path for Pages
+          REPO_NAME="${{ github.event.repository.name }}"
+          OWNER="${{ github.repository_owner }}"
+          if [ "$REPO_NAME" = "${OWNER}.github.io" ]; then
+            echo "VITE_BASE=/" >> $GITHUB_ENV
+          else
+            echo "VITE_BASE=/${REPO_NAME}/" >> $GITHUB_ENV
+          fi
           npm run build
           # Create 404.html for SPA routing fallback
           cp dist/index.html dist/404.html

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Page Not Found</title>
+    <meta http-equiv="refresh" content="0; url=/" />
+  </head>
+  <body>
+    <p>Redirecting to home...</p>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  // Set base path so built assets resolve correctly on GitHub Pages.
+  // Defaults to "/" which is correct for user/org pages like vid19.github.io.
+  // Can be overridden in CI by setting VITE_BASE environment variable.
+  base: process.env.VITE_BASE || "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
Enable GitHub Pages deployment for the Vite application.

This PR introduces a GitHub Actions workflow to build and deploy the Vite application to GitHub Pages. It also includes a `404.html` for single-page application (SPA) routing fallback and dynamically configures Vite's `base` path to correctly handle both user/organization and project GitHub Pages URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca492d1f-d9f4-4fe1-bc91-a31d6eb2773d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca492d1f-d9f4-4fe1-bc91-a31d6eb2773d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

